### PR TITLE
Amend `max()` to `pmax()` in 2 places

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: mr.raps
 Title: Two Sample Mendelian Randomization using Robust Adjusted Profile
     Score
-Version: 0.4.2
+Version: 0.4.3
 Authors@R: c(
     person("Qingyuan", "Zhao", , "qingyzhao@gmail.com", role = c("aut", "cre")),
     person("Jingshu", "Wang", , "wangjingshususan@gmail.com", role = "aut")

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,4 +37,4 @@ Remotes:
     ropensci/rsnps
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,3 @@
+# mr.raps 0.4.3
+
+* In `mr.raps.overdispersed.robust()` the use of `max()` has been replaced with `pmax()`, thanks @andrewjiaruiyang

--- a/R/core.R
+++ b/R/core.R
@@ -467,11 +467,11 @@ mr.raps.overdispersed.robust <- function(b_exp, b_out, se_exp, se_out, loss.func
 
     robust.loglike.fixtau <- function(beta, tau2) {
         alpha.hat <- 0
-        - (1/2) * sum(rho((b_out - alpha.hat - b_exp * beta) / sqrt(max(0, tau2 + se_out^2 + se_exp^2 * beta^2))))
+        - (1/2) * sum(rho((b_out - alpha.hat - b_exp * beta) / sqrt(pmax(0, tau2 + se_out^2 + se_exp^2 * beta^2))))
     }
 
     robust.E <- function(beta, tau2) {
-        t <- (b_out - beta * b_exp) / sqrt(max(0, tau2 + se_out^2 + se_exp^2 * beta^2))
+        t <- (b_out - beta * b_exp) / sqrt(pmax(0, tau2 + se_out^2 + se_exp^2 * beta^2))
         se_exp^2 * (t * rho(t, deriv = 1) - delta) / (tau2 + se_out^2 + se_exp^2 * beta^2)
     }
 


### PR DESCRIPTION
This implements the suggested fix in #16 

Under this new version the example returns what I think are the expected estimates.

``` r
library(mr.raps)
data(bmi.sbp)

beta.exposure <- bmi.sbp$beta.exposure
beta.outcome  <- bmi.sbp$beta.outcome
se.exposure   <- bmi.sbp$se.exposure
se.outcome    <- bmi.sbp$se.outcome

raps_huber <- mr.raps.mle(beta.exposure, beta.outcome, se.exposure, se.outcome, loss.function = "huber", over.dispersion = TRUE)

paste("raps huber point estimate = ",raps_huber$beta.hat)
#> [1] "raps huber point estimate =  0.378082707798569"
paste("raps tukey tau2 estimate = ",raps_huber$tau2.hat)
#> [1] "raps tukey tau2 estimate =  0.000467960435694382"
```

<sup>Created on 2025-10-31 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>

(whereas using the current version the raps huber point estimate comes out at 0.9698, and taps tukey tau2 estimate is 0.)

Closes #16 